### PR TITLE
fix: 左侧label与右侧按钮font-family不同

### DIFF
--- a/src/el-data-tree.vue
+++ b/src/el-data-tree.vue
@@ -49,7 +49,7 @@
             <!-- @slot 可定制的节点标签内容, 参数为 { data } -->
             <slot name="node-label" :data="data">{{ node.label }}</slot>
           </span>
-          <span @click="e => e.stopPropagation()" v-if="hasOperation">
+          <span @click="e => e.stopPropagation()" v-if="hasOperation" class="operation-btns-wrap">
             <template v-if="extraButtonsType === 'text'">
               <el-button
                 v-if="hasNew"
@@ -752,11 +752,17 @@ $delete-color = #E24156;
     justify-content: space-between;
     font-size: 14px;
     padding-right: 8px;
-  }
 
-  .custom-tree-node-label {
-    overflow: hidden;
-    text-overflow: ellipsis;
+    .custom-tree-node-label {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .operation-btns-wrap {
+      .el-button {
+        font-family: inherit;
+      }
+    }
   }
 
   .delete-button {

--- a/src/el-data-tree.vue
+++ b/src/el-data-tree.vue
@@ -49,7 +49,7 @@
             <!-- @slot 可定制的节点标签内容, 参数为 { data } -->
             <slot name="node-label" :data="data">{{ node.label }}</slot>
           </span>
-          <span @click="e => e.stopPropagation()" v-if="hasOperation" class="operation-btns-wrap">
+          <span @click="e => e.stopPropagation()" v-if="hasOperation" class="custom-tree-node-btns">
             <template v-if="extraButtonsType === 'text'">
               <el-button
                 v-if="hasNew"
@@ -758,7 +758,7 @@ $delete-color = #E24156;
       text-overflow: ellipsis;
     }
 
-    .operation-btns-wrap {
+    .custom-tree-node-btns {
       .el-button {
         font-family: inherit;
       }


### PR DESCRIPTION
close #31

- fix:  左侧label与右侧按钮font-family不同

## Why
button 有默认font-family: Arial，而左侧的font-family则是继承的，看起来不统一

## How
给 右侧操作按钮 设置 font-family: inherit; 

You may use xmind or other mind map to show you logic
![image](https://user-images.githubusercontent.com/26338853/59750692-c7c5b380-92b1-11e9-8b1d-66d2b214c853.png)


## Test
修改父级font-family两侧字体能保持一致
修改body font-family两侧字体能保持一致

