### PR TITLE
fix: treeAttrs.defaultExpandedKeys is undefined

### DIFF
--- a/src/el-data-tree.vue
+++ b/src/el-data-tree.vue
@@ -122,6 +122,7 @@ const dataPath = 'payload.content'
 const dialogForm = 'dialogForm'
 const defaultParentKey = 'parentId'
 const defaultTreeAttrs = {
+  defaultExpandedKeys: [],
   highlightCurrent: true,
   props: {
     children: 'children',
@@ -406,7 +407,7 @@ export default {
     checkedKeys(keys) {
       this.updateCheckedKeys(keys)
     },
-    'treeAttrs.defaultExpandedKeys': {
+    'treeAttributes.defaultExpandedKeys': {
       handler(val) {
         val.forEach(item => this.cacheExpandedKeys.add(item))
         this.updateDefaultExpandKeys()


### PR DESCRIPTION
## Why
Error occur when defaulExpandedKeys unset.

## Test
**before**
![image](https://user-images.githubusercontent.com/27187946/60480231-5dead800-9cbb-11e9-94b8-5e4794fde576.png)

**after**
![image](https://user-images.githubusercontent.com/27187946/60480281-a30f0a00-9cbb-11e9-9ec2-fb6eddd3f117.png)

