### PR TITLE
feat: 注册组件时可以设置默认折叠状态

### DIFF
--- a/src/el-data-tree.vue
+++ b/src/el-data-tree.vue
@@ -409,7 +409,9 @@ export default {
      */
     collapsable: {
       type: Boolean,
-      default: false
+      default() {
+        return this.$elDataTreeOptions.collapsable || false
+      }
     }
   },
   data() {

--- a/src/el-data-tree.vue
+++ b/src/el-data-tree.vue
@@ -410,7 +410,7 @@ export default {
     collapsable: {
       type: Boolean,
       default() {
-        return this.$elDataTreeOptions.collapsable || false
+        return _get(this, '$elDataTreeOptions.collapsable') || false
       }
     }
   },

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,8 @@ import Component from './el-data-tree.vue'
 // the same plugin more than once,
 // so calling it multiple times on the same plugin
 // will install the plugin only once
-Component.install = Vue => {
+Component.install = (Vue, options = {}) => {
+  Vue.prototype.$elDataTreeOptions = options
   Vue.component(Component.name, Component)
 }
 


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why

算得上是一种便捷行为，项目里使用组件数量少还好。
如果项目里使用组件多的话，一个个的找再添加 `collapsable` 还是比较痛苦的。

## How

```js
// 注册组件时
Vue.use(ElDataTree, {
  collapsable: true, // 变更默认折叠状态为 `true`
})
```

## 其他

如果有其他需要支持设置默认的就留言评论咯。